### PR TITLE
macOS name of Version 10.15 corrected to Catalina.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Jump to information on [macOS Mojave 10.14](#macos-mojave-1014)
 
 ---
 
-# macOS Mojave 10.15
+# macOS Catalina 10.15
 
 **IMPORTANT**: `set-desktop-catalina.sh` has been tested using **macOS Catalina Beta [ Developer 19A487l and Public 19A487m ]**
 


### PR DESCRIPTION
The name of the version was Mojave before, changed it to Catalina.